### PR TITLE
Fix hidden constructors warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes (😱!!!):
 
+- Removed `Newtype` instance for `TacitString`
+
 New features:
 
 Bugfixes:

--- a/src/Data/TacitString.purs
+++ b/src/Data/TacitString.purs
@@ -4,11 +4,9 @@ module Data.TacitString
   ) where
 
 import Prelude
-import Data.Newtype (class Newtype)
 
 newtype TacitString = TacitString String
 
-derive instance newtypeTacitString :: Newtype TacitString _
 derive instance eqTacitString :: Eq TacitString
 derive instance ordTacitString :: Ord TacitString
 


### PR DESCRIPTION
Exported types with hidden constructors but `Generic` or `Newtype` instances will trigger a warning in v0.14.0.

See https://github.com/purescript/purescript/pull/3907.