### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -29,3 +31,6 @@ jobs:
 
       - name: Build source
         run: spago build --no-install --purs-args '--censor-lib --strict'
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#21 by @thomashoneyman)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-fixed-points/releases/tag/v6.0.0) - 2021-02-26
 

--- a/src/Data/Functor/Mu.purs
+++ b/src/Data/Functor/Mu.purs
@@ -19,11 +19,11 @@ newtype Mu f = In (f (Mu f))
 
 -- | Rewrites a tree along a natural transformation.
 transMu
-  ∷ ∀ f g
-  . (Functor g)
-  ⇒ f ~> g
-  → Mu f
-  → Mu g
+  :: forall f g
+   . (Functor g)
+  => f ~> g
+  -> Mu f
+  -> Mu g
 transMu η =
   roll
     <<< map (transMu η)


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
